### PR TITLE
ci: stop caching `npm install` to work around deprecation

### DIFF
--- a/.github/workflows/build-gsp.yml
+++ b/.github/workflows/build-gsp.yml
@@ -20,7 +20,6 @@ jobs:
         # causes `actions/checkout@v2` to fetch the entire history, instead of
         # just the most recent commit.
         fetch-depth: 0
-    - uses: c-hive/gha-npm-cache@v1
     - name: Install dependencies
       run: npm install
     - name: Build GSP


### PR DESCRIPTION
To work around <https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts>. That's not ideal, but I don't want to invest time in this.